### PR TITLE
build(dependencies): 🧱 update crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,18 +49,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ description = "Function to determine neighbours of a point within a direction an
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
 thiserror = "2.0.3"


### PR DESCRIPTION
# Description

Update dependencies:

Bumps serde_json from 1.0.132 to 1.0.133.
Bumps serde from 1.0.214 to 1.0.215.
    Updating serde v1.0.214 -> v1.0.215
    Updating serde_derive v1.0.214 -> v1.0.215
    Updating serde_json v1.0.132 -> v1.0.133
    Blocking waiting for file lock on package cache
  Downloaded serde_json v1.0.133
  Downloaded 1 crate (150.7 KB) in 4.97s
    Blocking waiting for file lock on package cache
   Compiling proc-macro2 v1.0.89
   Compiling unicode-ident v1.0.13
   Compiling serde v1.0.215
   Compiling thiserror v2.0.3
   Compiling serde_json v1.0.133
    Checking memchr v2.7.4
    Checking ryu v1.0.18
    Checking itoa v1.0.11
   Compiling quote v1.0.37
   Compiling syn v2.0.87
   Compiling serde_derive v1.0.215
   Compiling thiserror-impl v2.0.3

## Type of change

- [X] Dependency update

# How Has This Been Tested?

- [X] cargo test run with all tests passing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
